### PR TITLE
Clip functionality update and README update. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 ## Aim
 
 - A Bot built to create a new level of interactivity between my community and I with commands and other ambitious functions such as visual and audio cues. 
+
+
+# Current "fix this pleeeeease" list
+
+- Show !followage in "years, months, days, seconds ago" format. 
+- Data persistence. Some of the commands use a counter that increments upon each use, so the bot can't just reset those counter values to 0 upon each reboot. Look into database. 
+- Clip command has several issues that need fixing. 
+  - - Clip currently says that RomculusTV has made the clip, instead of the person who used !clip. 
+  - - Clip currently sends a finished, edited clip to the user, rather than an edit URL they can use to edit the clip themselves. 
+  - - Command doesn't work if it attempts to return a whisper. 

--- a/src/Commands/Clip.js
+++ b/src/Commands/Clip.js
@@ -1,21 +1,25 @@
 import fetch from "node-fetch"
 
-const Clip = (API_CLIENT_ID, CLIENT_SECRET, AUTH_CODE, RERESH_CODE) => {
+
+const refreshToken = (API_CLIENT_ID, CLIENT_SECRET, REFRESH_CODE) => {
 // Refresh Access Token
-let accessToken = "";
-fetch(`https://id.twitch.tv/oauth2/token?grant_type=refresh_token&refresh_token=${RERESH_CODE}&client_id=${API_CLIENT_ID}&client_secret=${CLIENT_SECRET}`, {
+let accessToken = ""
+return fetch(`https://id.twitch.tv/oauth2/token?grant_type=refresh_token&refresh_token=${REFRESH_CODE}&client_id=${API_CLIENT_ID}&client_secret=${CLIENT_SECRET}`, {
   method: "POST"
 })
-  .then((response) => {
+  .then((response) => {  
     return response.json()})
       .then((data) => {
-      accessToken = data["access_token"]
-      console.log(data);      
-    } 
+     
+      accessToken = `Bearer ${data["access_token"]}`;   
+      return accessToken    
+} 
   )
-// Make a promise here to make sure this runs asynchronously.....
 
+}
 
+const createClip = (client, channel, userstate, accessToken, API_CLIENT_ID) => {
+// console.log("Here's your access token! " + accessToken)
 fetch(`https://api.twitch.tv/helix/clips?broadcaster_id=36866421`, {
       method: "POST",
       headers: {
@@ -26,8 +30,16 @@ fetch(`https://api.twitch.tv/helix/clips?broadcaster_id=36866421`, {
           return response.json()
         }).then((list) => {
           console.log(list)
+          client.say(channel,`${userstate["display-name"]} Thanks for clipping! Edit your clip here! ${list.data[0]["edit_url"]} `)
         }
       )
+}
+
+const Clip = (client, channel, userstate, API_CLIENT_ID, CLIENT_SECRET, REFRESH_CODE) => {
+  refreshToken(API_CLIENT_ID, CLIENT_SECRET, REFRESH_CODE)
+    .then((accessToken) => {
+    createClip(client, channel, userstate, accessToken, API_CLIENT_ID)})
+ 
 }
 
 export default Clip;

--- a/src/Commands/Clip.js
+++ b/src/Commands/Clip.js
@@ -1,5 +1,33 @@
-const Clip = () => {
-  // Code goes here
+import fetch from "node-fetch"
+
+const Clip = (API_CLIENT_ID, CLIENT_SECRET, AUTH_CODE, RERESH_CODE) => {
+// Refresh Access Token
+let accessToken = "";
+fetch(`https://id.twitch.tv/oauth2/token?grant_type=refresh_token&refresh_token=${RERESH_CODE}&client_id=${API_CLIENT_ID}&client_secret=${CLIENT_SECRET}`, {
+  method: "POST"
+})
+  .then((response) => {
+    return response.json()})
+      .then((data) => {
+      accessToken = data["access_token"]
+      console.log(data);      
+    } 
+  )
+// Make a promise here to make sure this runs asynchronously.....
+
+
+fetch(`https://api.twitch.tv/helix/clips?broadcaster_id=36866421`, {
+      method: "POST",
+      headers: {
+        'Client-ID': API_CLIENT_ID,
+        'Authorization': accessToken
+        
+        }}).then((response) => {
+          return response.json()
+        }).then((list) => {
+          console.log(list)
+        }
+      )
 }
 
 export default Clip;

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@ function parseISOString(s) {
         return new Date(Date.UTC(b[0], --b[1], b[2], b[3], b[4], b[5], b[6]));
 }
 
-const API_TOKEN = process.env.TOKEN
+const REFRESH_CODE = process.env.REFRESH_TOKEN
+const AUTH_CODE = process.env.AUTHORIZATION_CODE
+const CLIENT_SECRET = process.env.TOKEN
 const API_CLIENT_ID = process.env.CLIENT_ID
 const client = new tmi.Client({
     identity: {
@@ -86,7 +88,7 @@ client.on('message', (channel, userstate, message, self) => {
 
 // Clip
     if(command === "!clip"){
-    // put clip command here. 
+    Clip(API_CLIENT_ID, CLIENT_SECRET, AUTH_CODE, REFRESH_CODE)
 }
 
 // Slap 

--- a/src/index.js
+++ b/src/index.js
@@ -87,9 +87,9 @@ client.on('message', (channel, userstate, message, self) => {
 }
 
 // Clip
-    if(command === "!clip"){
-    Clip(API_CLIENT_ID, CLIENT_SECRET, AUTH_CODE, REFRESH_CODE)
-}
+//     if(command === "!clip"){
+//     Clip(client, channel, userstate, API_CLIENT_ID, CLIENT_SECRET, REFRESH_CODE)
+// }
 
 // Slap 
     if(command === "!slap"){


### PR DESCRIPTION
Still got things to work on, but the base !clip functionality is now working. 
To add to !clip:
Send it to Discord using Discord Webhook to fix two issues:
1. Clip identity can then be found in Discord and ignored on Twitch. Twitch doesn't allow attribution of clip identity to others for most likely security reasons. 
2. It allows for a storage of said clips for easy access in making highlight reels. 