### PR TITLE
Clip.js and Discord.js

### DIFF
--- a/src/Commands/Clip.js
+++ b/src/Commands/Clip.js
@@ -30,13 +30,14 @@ return fetch(`https://api.twitch.tv/helix/clips?broadcaster_id=36866421`, {
       return response.json()
     })
       .then((list) => {
-        let editURL = list.data[0]["edit_url"];
+        let editURL = `https://clips.twitch.tv/${list.data[0]["id"]}`;
+        console.log(editURL)
         let user = userstate["display-name"];
         client.say(channel,`${user} Thanks for clipping! You'll find your clip in the Discord #clips-highlights channel.`)
     
           return {
           user: userstate["display-name"],
-          editURL: list.data[0]["edit_url"]
+          editURL: `https://clips.twitch.tv/${list.data[0]["id"]}`
         }})
   
 }

--- a/src/Commands/Discord.js
+++ b/src/Commands/Discord.js
@@ -1,0 +1,5 @@
+const Discord = (client, channel) => {
+  client.say(channel, "Join the community Discord! https://discord.gg/8VyXumH")
+}
+
+export default Discord

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import fetch from "node-fetch";
 import moment from "moment";
 import Dice from "./Commands/Dice"
-
+import Discord from "./Commands/Discord"
 import Lurk from "./Commands/Lurk"
 import Hug from "./Commands/Hug"
 import Quote6 from "./Commands/Quote6"


### PR DESCRIPTION
Modified: Clip command to send the clip itself, not an editURL that they couldn't use.
Rectified: Discord command was removed by accident, but is now reinstated.